### PR TITLE
chore: remove whitespace in osv-scanner config

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -72,7 +72,7 @@ reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but 
 name = "github.com/golang/groupcache"
 version = "0.0.0-20241129210726-2c02b8208cf8"
 ecosystem = "Go"
-license.override = ["Apache-2.0 "]
+license.override = ["Apache-2.0"]
 reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/119 is resolved"
 
 [[PackageOverrides]]


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix license scan by removing whitespace in`github.com/golang/groupcache` license override.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
